### PR TITLE
New version number for Nic C changes

### DIFF
--- a/TypeEquality/TypeEquality.fsproj
+++ b/TypeEquality/TypeEquality.fsproj
@@ -7,7 +7,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Tailcalls>true</Tailcalls>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.0.1</Version>
+    <Version>0.2.0</Version>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>TypeEquality</Product>


### PR DESCRIPTION
SemVer.org says update the middle version number for adding to API.  Decided we'd go for a 2 rather than 1 just because it felt right.