### PR TITLE
Remove outdated doc which claims not to expose unsafe believeMe-like things

### DIFF
--- a/TypeEquality/Teq.fs
+++ b/TypeEquality/Teq.fs
@@ -60,10 +60,8 @@ module Teq =
     /// More efficient than mapping the application of the teq across the functor.
     /// i.e. Use Teq.Cong.list in preference to List.map (Teq.cast)
     ///
-    /// If you need to make your own Teq.Cong.foo for your own functor 'Foo<_>', then the onus
-    /// is on your to verify that doing that is sane, and to implement it yourself (since
-    /// exposing the unsafe functions used internally here would make it too easy for
-    /// consumers to shoot themselves in the foot).
+    /// If you need to make your own Teq.Cong.foo for your own functor 'Foo<_>' using believeMe,
+    /// then the onus is on you to verify that doing that is sane.
     [<RequireQualifiedAccess>]
     module Cong =
 

--- a/TypeEquality/Teq.fsi
+++ b/TypeEquality/Teq.fsi
@@ -53,10 +53,8 @@ module Teq =
     /// More efficient than mapping the application of the teq across the functor.
     /// i.e. Use Teq.Cong.list in preference to List.map (Teq.cast)
     ///
-    /// If you need to make your own Teq.Cong.foo for your own functor 'Foo<_>', then the onus
-    /// is on your to verify that doing that is sane, and to implement it yourself (since
-    /// exposing the unsafe functions used internally here would make it too easy for
-    /// consumers to shoot themselves in the foot).
+    /// If you need to make your own Teq.Cong.foo for your own functor 'Foo<_>' using believeMe,
+    /// then the onus is on you to verify that doing that is sane.
     [<RequireQualifiedAccess>]
     module Cong =
 


### PR DESCRIPTION
`believeMe` _is_ exposed to allow user-defined functors to be cong'd, sensibly so, in my opinion. I suggest removing the docs which seem to claim otherwise (presumably they are outdated after a change on stance on this issue?).